### PR TITLE
fixes checkDefaultValues() issue on RBN; issue was that checkDefaultV…

### DIFF
--- a/client/app/dashboard/model/edit/ModelEdit.js
+++ b/client/app/dashboard/model/edit/ModelEdit.js
@@ -137,7 +137,7 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     for (var i in keys) {
       var key = keys[i];
       var property = $scope.model.properties[key];
-      if ((property && property.display) && (!$scope.data[key] || property.display.forceDefaultOnSave)) {
+      if ((property && property.display) && (typeof $scope.data[key] === 'undefined' || $scope.data[key] === null || property.display.forceDefaultOnSave)) {
         if (typeof property["default"] !== 'undefined') $scope.data[key] = property["default"];
         if (typeof property.display.evalDefault !=='undefined') $scope.data[key] = eval(property.display.evalDefault);
       }


### PR DESCRIPTION
fixes checkDefaultValues() issue on RBN; issue was that checkDefaultValues() was evaluating the ‘default’ key to determine if default values should be applied, however, in RBN, we use the ’default’ as the default value to set a field. In RBN, one field ‘default’ is set to a boolean true/false and when checkDefaultValues() evaluates it, it assumes the false value implies no data is set for the field and there for the default value should be applied instead;