### PR TITLE
Ability to control model field ordering, and hide fields from editor

### DIFF
--- a/client/app/dashboard/model/edit/ModelEdit.js
+++ b/client/app/dashboard/model/edit/ModelEdit.js
@@ -36,13 +36,20 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     if (!$scope.action.options) $scope.action.options = { model: $stateParams.model, key: $stateParams.key };
 
     $scope.model = Config.serverParams.models[$scope.action.options.model];
-
     //Make Key field readonly
     if ($scope.action.options.key) {
       var key = $scope.action.options.key;
       if (!$scope.model.properties[key].display) $scope.model.properties[key].display = {};
       $scope.model.properties[key].display.readonly = true;
     }
+
+    //Give each property display definition an order property if undefined
+    var i = 0;
+    angular.forEach($scope.model.properties,function(item,key,index){
+      if(!item.display) item.display = {};
+      if(item.display.order === undefined) item.display.order = i;
+      i++;
+    });
 
     $scope.isLoading = true;
     $scope.data = {};
@@ -86,13 +93,22 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     if ($scope.action.options.display) $scope.modelDisplay = $scope.model[$scope.action.options.display];
     if (!$scope.modelDisplay || $scope.modelDisplay.length == 0) {
       $scope.modelDisplay = [];
-      var keys = Object.keys( $scope.model.properties);
+      var keys = Object.keys($scope.model.properties);
       for (var i in keys) {
         var key = keys[i];
+        //Hide field if display.hidden is set to true in loopback model json
+        if( $scope.model.properties[key].display && $scope.model.properties[key].display.hidden === true ) continue;
         $scope.modelDisplay.push(key);
         if (!$scope.data[key]) $scope.data[key] = null;
       }
     }
+    //Sort fields by order property
+    $scope.modelDisplay.sort(function(a,b){
+      if( $scope.model.properties[a].display.order === null ) return 0;
+      if( $scope.model.properties[a].display.order < $scope.model.properties[b].display.order ) return -1;
+      if( $scope.model.properties[a].display.order > $scope.model.properties[b].display.order ) return 1;
+      return 0;
+    })
   };
 
 

--- a/client/app/dashboard/model/edit/ModelEdit.js
+++ b/client/app/dashboard/model/edit/ModelEdit.js
@@ -47,7 +47,8 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     var i = 0;
     angular.forEach($scope.model.properties,function(item,key,index){
       if(!item.display) item.display = {};
-      if(item.display.order === undefined) item.display.order = i;
+      if(!item.display.options) item.display.options = {};
+      if(item.display.options.order === undefined) item.display.options.order = i;
       i++;
     });
 
@@ -97,16 +98,16 @@ angular.module('dashboard.Dashboard.Model.Edit', [
       for (var i in keys) {
         var key = keys[i];
         //Hide field if display.hidden is set to true in loopback model json
-        if( $scope.model.properties[key].display && $scope.model.properties[key].display.hidden === true ) continue;
+        if( $scope.model.properties[key].display.options && $scope.model.properties[key].display.options.hidden === true ) continue;
         $scope.modelDisplay.push(key);
         if (!$scope.data[key]) $scope.data[key] = null;
       }
     }
     //Sort fields by order property
     $scope.modelDisplay.sort(function(a,b){
-      if( $scope.model.properties[a].display.order === null ) return 0;
-      if( $scope.model.properties[a].display.order < $scope.model.properties[b].display.order ) return -1;
-      if( $scope.model.properties[a].display.order > $scope.model.properties[b].display.order ) return 1;
+      if( $scope.model.properties[a].display.options.order === null ) return 0;
+      if( $scope.model.properties[a].display.options.order < $scope.model.properties[b].display.options.order ) return -1;
+      if( $scope.model.properties[a].display.options.order > $scope.model.properties[b].display.options.order ) return 1;
       return 0;
     })
   };


### PR DESCRIPTION
Adds support for an `order` param in a model property's display definition, which can be used to control the sequence a model's fields are ordered in the editor.

Similarly, adds support for a `hidden` param which can be used to hide a field from the editor.