### PR TITLE
Caching Improvements

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -6,6 +6,7 @@ angular.module('dashboard', [
   'dashboard.directives',
   'dashboard.filters',
 
+  'dashboard.services.Cache',
   'dashboard.services.Session',
 
   'templates-app',
@@ -54,7 +55,7 @@ angular.module('dashboard', [
 
 })
 
-.controller('AppCtrl', function AppCtrl ($scope, $location , $state , $rootScope, $timeout, $document, SessionService, Config) {
+.controller('AppCtrl', function AppCtrl ($scope, $location , $state , $rootScope, $timeout, $document, SessionService, CacheService, Config) {
   $rootScope.$state = $state;
   if (Config.serverParams.gaTrackingId) ga('create', Config.serverParams.gaTrackingId, 'auto');
 
@@ -79,7 +80,7 @@ angular.module('dashboard', [
   });
 
   $rootScope.logOut = function(){
-    localStorage.clear(); //clear out caching
+    CacheService.reset(); //clear out caching
     SessionService.logOut()
       .then(function(result){
         if (Config.serverParams.loginState) {

--- a/client/app/dashboard/model/edit/ModelEdit.js
+++ b/client/app/dashboard/model/edit/ModelEdit.js
@@ -2,6 +2,7 @@ angular.module('dashboard.Dashboard.Model.Edit', [
   'dashboard.Dashboard.Model.Edit.SaveDialog',                                                
   'dashboard.Config',
   'dashboard.directives.ModelField',
+  'dashboard.services.Cache',
   'dashboard.services.GeneralModel',
   'dashboard.services.FileUpload',
   'ui.router',
@@ -24,7 +25,7 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     ;
 })
 
-.controller('ModelEditCtrl', function ModelEditCtrl($rootScope, $scope, $cookies, $stateParams, $state, $window, $modal, Config, GeneralModelService, FileUploadService, $location) {
+.controller('ModelEditCtrl', function ModelEditCtrl($rootScope, $scope, $cookies, $stateParams, $state, $window, $modal, Config, GeneralModelService, FileUploadService, CacheService, $location) {
 
   var modalInstance = null;
       
@@ -154,7 +155,12 @@ angular.module('dashboard.Dashboard.Model.Edit', [
       controller: 'ModelEditSaveDialogCtrl',
       scope: $scope
     });
-    save();
+    save(function(){
+      if( $scope.action.options && $scope.action.options.returnAfterEdit) {
+        $window.history.back();
+      }
+      CacheService.clear($scope.action.options.model);
+    });
   };
   
   $scope.clickDeleteModel = function(data) {
@@ -164,12 +170,14 @@ angular.module('dashboard.Dashboard.Model.Edit', [
       //Soft Delete
       $scope.data[$scope.model.options.softDeleteProperty] = true;
       save(function() {
+        CacheService.clear($scope.action.options.model);
         $window.history.back();
       });
     } else {
       //Hard Delete
       GeneralModelService.remove($scope.model.plural, id)
       .then(function(response) {
+        CacheService.clear($scope.action.options.model);
         $window.history.back();
       }, function(error) {
         if (typeof error === 'object' && error.message) {

--- a/client/app/dashboard/model/list/ModelList.js
+++ b/client/app/dashboard/model/list/ModelList.js
@@ -1,6 +1,7 @@
 angular.module('dashboard.Dashboard.Model.List', [
   'dashboard.Dashboard.Model.Edit.SaveDialog',                                                
   'dashboard.Config',
+  'dashboard.services.Cache',
   'dashboard.services.GeneralModel',
   'dashboard.directives.ModelFieldReference',
   'ui.router',
@@ -22,7 +23,7 @@ angular.module('dashboard.Dashboard.Model.List', [
     ;
 })
 
-.controller('ModelListCtrl', function ModelListCtrl($scope, $cookies, $timeout, $state, $location, $window, $modal, Config, GeneralModelService, $location) {
+.controller('ModelListCtrl', function ModelListCtrl($scope, $cookies, $timeout, $state, $location, $window, $modal, Config, GeneralModelService, CacheService, $location) {
 
   var isFirstLoad = true;
   var modalInstance = null;
@@ -354,23 +355,31 @@ angular.module('dashboard.Dashboard.Model.List', [
     $scope.$emit("ModelListLoadItemsLoading");
     var params = setupPagination();
     //Rudimentary Caching (could use something more robust here)
-    var cacheKey = $scope.apiPath + JSON.stringify(params);
-    if(localStorage[cacheKey]) {
+    var cacheKey = CacheService.getKeyForAction($scope.action,params);
+    var isCached = false;
+    if(CacheService.get(cacheKey)) {
       try {
-        $scope.list = JSON.parse(localStorage[cacheKey]); //load from cache
+        isCached = true;
+        $scope.list = CacheService.get(cacheKey); //load from cache
         $scope.columnCount = $scope.list.length > 0 ? Object.keys($scope.list[0]).length : 0;
         processWindowSize(); //on first load check window size to determine if optional columns should be displayed
       } catch(e) {
+        isCached = false;
         console.warn("ModelList Cache is corupt for key = " + cacheKey);
       }
     }
+    if( isCached && angular.isArray($scope.list) ) return;
     GeneralModelService.list($scope.apiPath, params)
       .then(function(response) {
         if (!response) return; //in case http request was cancelled
         //console.log(JSON.stringify(response, null,'  '));
-        $scope.list = response;
+        if( $scope.action.options.resultField !== undefined
+          && response[$scope.action.options.resultField] !== undefined )
+          $scope.list = response[$scope.action.options.resultField];
+        else
+          $scope.list = response;
         $scope.columnCount = $scope.list.length > 0 ? Object.keys($scope.list[0]).length : 0;
-        localStorage[cacheKey] = JSON.stringify(response); //assign to cache
+        CacheService.set(cacheKey, $scope.list);
         processWindowSize(); //on first load check window size to determine if optional columns should be displayed
         $scope.$emit("ModelListLoadItemsLoaded");
         isFirstLoad = false;

--- a/client/app/login/Login.js
+++ b/client/app/login/Login.js
@@ -1,5 +1,6 @@
 angular.module('dashboard.Login', [
   'dashboard.Config',
+  'dashboard.services.Cache',
   'dashboard.services.Session',
   'ui.router'
 ])
@@ -16,7 +17,7 @@ angular.module('dashboard.Login', [
     });
 })
 
-.controller('LoginCtrl', function LoginCtrl($scope, $state, $window, Config, SessionService) {
+.controller('LoginCtrl', function LoginCtrl($scope, $state, $window, Config, SessionService, CacheService) {
 
   var self = this;
 
@@ -28,7 +29,7 @@ angular.module('dashboard.Login', [
   this.clickLogin = function() {
     SessionService.logIn($scope.login.email, $scope.login.password)
       .then(function(response) {
-        localStorage.clear(); //clear out all previous cache when login
+        CacheService.reset(); //clear out all previous cache when login
         $state.go('dashboard');
       })
       .catch(function(response) {

--- a/client/common/services/CacheService.js
+++ b/client/common/services/CacheService.js
@@ -1,0 +1,58 @@
+angular.module('dashboard.services.Cache', [
+  'dashboard.Config',
+  'dashboard.Utils',
+  'ngCookies'
+])
+
+.service('CacheService', function() {
+
+  this.KEY_DELIMITER = '-';
+
+  this.get = function(key) {
+    if(!localStorage.getItem(key)) return null;
+    try {
+        var cached = JSON.parse(localStorage.getItem(key));
+        return cached;
+    }
+    catch (e) {
+        return null;
+    }
+  };
+
+  this.set = function(key,value) {
+    try{
+        localStorage.setItem(key,JSON.stringify(value));
+    } catch(e) {
+        this.remove(key);
+    }
+  };
+
+  this.remove = function(key) {
+    localStorage.removeItem(key);
+  };
+
+  this.getKeyForAction = function(action,params) {
+    var key = action.options.model + this.KEY_DELIMITER + action.route;
+    if(params) key += this.KEY_DELIMITER + JSON.stringify(params);
+    return key;
+  }
+
+  this.clear = function(model) {
+    var key = model;
+    var regex = new RegExp('^'+key)
+    for(var k in localStorage)
+    {
+        if(regex.test(k))
+        {
+            this.remove(k);
+        }
+    }
+  };
+
+  this.reset = function()
+  {
+    localStorage.clear();
+  }
+})
+
+;


### PR DESCRIPTION
This pull request includes the following changes:

- Moves caching to CacheService
- Creates cache keys by appending model, route and params, and adds convenience method for clearing all requests for a model and route
- Clears a model's cached requests after adding/editing/removing a model instance
- Doesn't re-request models in list view if cached
- Gracefully handles quota exceeded error by wrapping localStorage.set in try/catch block
- Optionally look to a sub-property of a model's `list` response for list of result objects, if action.options. resultField is set