### PR TITLE
Custom api paths with paging parameters in querystring

### DIFF
--- a/client/app/dashboard/model/list/ModelList.js
+++ b/client/app/dashboard/model/list/ModelList.js
@@ -112,6 +112,7 @@ angular.module('dashboard.Dashboard.Model.List', [
       //Simple model list query
       $scope.apiPath = $scope.model.plural;
     }
+    $scope.origApiPath = $scope.apiPath;
     addQueryStringParams();
     $scope.getTotalServerItems();
     
@@ -222,6 +223,7 @@ angular.module('dashboard.Dashboard.Model.List', [
   function addQueryStringParams() {
     var queryStringParams = $location.search();
     $scope.queryStringParams = queryStringParams; //so nggrid cell templates can have access
+    $scope.apiPath = $scope.origApiPath;
     var keys = Object.keys(queryStringParams);
     for (var i in keys) {
       var key = keys[i];
@@ -327,6 +329,7 @@ angular.module('dashboard.Dashboard.Model.List', [
     delete sortInfo.columns; //cleanup sortInfo to declutter querystring
     $location.search("sortInfo", JSON.stringify(sortInfo));
     $location.replace(); //replaces current history state rather then create new one when chaging querystring
+    addQueryStringParams();
     return params;
   }
   

--- a/client/common/services/GeneralModelService.js
+++ b/client/common/services/GeneralModelService.js
@@ -12,8 +12,8 @@ angular.module('dashboard.services.GeneralModel', [
   /**
    * Returns a list of models given filter params (see loopback.io filters)
    */
-  this.list = function(model, params) {
-    var apiPath = model + '?access_token=' + $cookies.accessToken;
+  this.list = function(apiPath, params) {
+    var apiPath = apiPath + (apiPath.indexOf('?')>-1 ? '&' : '?') + 'access_token=' + $cookies.accessToken;
     Utils.apiCancel('GET', apiPath); //cancels any prior calls to method + path
     return Utils.apiHelper('GET', apiPath, params);
   };
@@ -21,7 +21,8 @@ angular.module('dashboard.services.GeneralModel', [
   /**
    * Returns the total number of records for a given model
    */
-  this.count = function(model, params) {
+  this.count = function(apiPath, params) {
+    if( apiPath.indexOf('?')>-1 ) apiPath = apiPath.substr(0,apiPath.indexOf('?'));
     var keys = Object.keys(params);
     for (var i in keys) {
       var key = keys[i];
@@ -32,7 +33,7 @@ angular.module('dashboard.services.GeneralModel', [
         //TODO: parse through the filter JSON string looking for the where clause
       }
     }
-    var apiPath = model + '/count?access_token=' + $cookies.accessToken;
+    apiPath = apiPath + '/count?access_token=' + $cookies.accessToken;
     Utils.apiCancel('GET', apiPath); //cancels any prior calls to method + path
     return Utils.apiHelper('GET', apiPath, params);
   };


### PR DESCRIPTION
I ran into a few issues when adding a custom api path containing paging params like the following:
`article?limit={pageSize}&page={currentPage}`

The first issue I found was that `addQueryStringParams` was only being called in `ModelList.init()`, so the api path would always represent the initial page of results. I updated `setupPagination()` to call `addQueryStringParams` at the end, right after it updates `$location`.

The second issue was that GeneralModelService was appending the `?access_token` to the path, so I made it add or append to the path based on the presence of a `?`. Because count() also uses the api path, I made it trim off the querystring at the top of the function.

Curious what you think about this approach.