### PR TITLE
allow custom api path for editing models

### DIFF
--- a/client/app/dashboard/model/edit/ModelEdit.js
+++ b/client/app/dashboard/model/edit/ModelEdit.js
@@ -57,6 +57,13 @@ angular.module('dashboard.Dashboard.Model.Edit', [
       }
     }
 
+    if ($scope.action.options.api) {
+      $scope.apiPath = $scope.action.options.api;
+    } else if ($scope.action.options.model) {
+      //Simple model list query
+      $scope.apiPath = $scope.model.plural;
+    }
+
     //Loop through fields and check for forced default fields
     GeneralModelService.checkDefaultValues($scope.model, $scope.data);
     
@@ -67,7 +74,7 @@ angular.module('dashboard.Dashboard.Model.Edit', [
     if (id) {
       $scope.isEdit = true;
       $scope.modelDisplay = null; //reset model display to prevent caching
-      GeneralModelService.get($scope.model.plural, id)
+      GeneralModelService.get($scope.apiPath, id)
       .then(function(response) {
         if (!response) return;  //in case http request was cancelled
         $scope.data = response;

--- a/client/common/services/GeneralModelService.js
+++ b/client/common/services/GeneralModelService.js
@@ -41,8 +41,13 @@ angular.module('dashboard.services.GeneralModel', [
   /**
    * Get the model data for a particular ID
    */
-  this.get = function(model, id, params) {
-    var apiPath = model + '/' + id + '?access_token=' + $cookies.accessToken;
+  this.get = function(apiPath, id, params) {
+    if(apiPath.indexOf("{id}")>-1) {
+      apiPath = apiPath.split('?');
+      apiPath = apiPath[0].replace("{id}",id) + '?access_token=' + $cookies.accessToken + '&' + apiPath[1];
+    } else {
+      apiPath = apiPath + '/' + id + '?access_token=' + $cookies.accessToken;
+    }
     //Below Utils.apiCancel() call appears to break when getting user profile
     //Utils.apiCancel('GET', apiPath); //cancels any prior calls to method + path
     return Utils.apiHelper('GET', apiPath, params);


### PR DESCRIPTION
Since ModelEdit loads models via the plural name only, any editable relations must be included in the model's default scope. Since this is a global setting API responses can get bloated as a result, particularly when those models are included as relations elsewhere.

Similar to ModelList, this allows for a custom api path to be set in `action.options.api`. So that string can contain filters and other query string arguments, the model's id can be specified in the string via `{id}` and will be replaced, and `access_token` will be appended accordingly. 