### PR TITLE
allow adding of html attributes to input fields from display.inputAttr

### DIFF
--- a/client/common/directives/ModelField/ModelField.js
+++ b/client/common/directives/ModelField/ModelField.js
@@ -248,6 +248,16 @@ angular.module('dashboard.directives.ModelField', [
     }
     return template;
   }
+
+  function addInputAttributes(element, inputAttr) {
+    var $input = $(element).find('input');
+    if (inputAttr && $input) {
+      for(var attr in inputAttr) {
+        $input.attr(attr, inputAttr[attr]);
+      }
+    }
+  }
+
   return {
     restrict: 'E',
     scope: {
@@ -399,6 +409,9 @@ angular.module('dashboard.directives.ModelField', [
         } else {
           element.html(getTemplate(property.display.type, scope)).show();
         }
+        // add input attributes if specified in schema
+        addInputAttributes(element, scope.property.display.inputAttr);
+
         $compile(element.contents())(scope);
 
     }


### PR DESCRIPTION
Allow adding of html attributes to input fields by simply specifying an inputAttr property containing an object with key value pairs of html attributes. An example is use case is specifying the maxlength for the phone number fields, this can now be easily achieved by specifying the model config like:
```javascript
phoneNumber: {
  display: {
    type: "phoneNumber",
    label: "Phone Number",
    region: "US",
    inputAttr: {
        maxlength: "14",
    } 
  }
}
````