### PR TITLE
feature/DD-605-web-app-idle-timeout-behavior

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -73,7 +73,7 @@ angular.module('dashboard', [
       event.preventDefault();
     }
     //Handle Idle Timer for SessionTimeout
-    if (Config.serverParams.sessionTimeout) {
+    if (Config.serverParams.sessionTimeout && location.host() != 'localhost') {
       setSessionTimeout();
       $document.on("click keydown keyup scroll DOMMouseScroll mousedown mousemove mousewheel touchstart touchmove", function() {
         if(!$scope.$modalInstance) {

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -21,10 +21,10 @@ angular.module('dashboard', [
   $locationProvider.html5Mode(true);
 
   $stateProvider
-      .state('public', {
-        abstract: true,
-        template: '<ui-view />'
-      });
+    .state('public', {
+      abstract: true,
+      template: '<ui-view />'
+    });
 
   $urlRouterProvider.deferIntercept(); // defer routing until custom modules are loaded
 })
@@ -34,10 +34,10 @@ angular.module('dashboard', [
   var modulesLoaded = false;
   if (Config.serverParams.customModules) {
     $ocLazyLoad.load(Config.serverParams.customModules)
-        .then(function() {
-          modulesLoaded = true;
-          $rootScope.$broadcast('modulesLoaded');
-        }, function(error){console.log(error)});
+      .then(function() {
+        modulesLoaded = true;
+        $rootScope.$broadcast('modulesLoaded');
+      }, function(error){console.log(error)});
   } else {
     modulesLoaded = true;
   }
@@ -94,15 +94,15 @@ angular.module('dashboard', [
   $rootScope.logOut = function() {
     CacheService.reset(); //clear out caching
     SessionService.logOut()
-        .then(function (result) {
-          if (Config.serverParams.loginState) {
-            $state.go(Config.serverParams.loginState); //custom login controller
-          } else {
-            $state.go('public.login');
-          }
-        })
-        .catch(function (error) {
-        });
+      .then(function (result) {
+        if (Config.serverParams.loginState) {
+          $state.go(Config.serverParams.loginState); //custom login controller
+        } else {
+          $state.go('public.login');
+        }
+      })
+      .catch(function (error) {
+      });
   };
 
   function sessionTimeoutWarning() {
@@ -136,4 +136,3 @@ angular.module('dashboard', [
     $rootScope.timeoutId = $interval(sessionTimeoutWarning, Config.serverParams.sessionTimeout - $scope.warningTimeout, 1);
   }
 });
-

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -37,7 +37,7 @@ angular.module('dashboard', [
       .then(function() {
         modulesLoaded = true;
         $rootScope.$broadcast('modulesLoaded');
-      }, function(error){console.log(error)});
+      });
   } else {
     modulesLoaded = true;
   }

--- a/client/app/dashboard/alert/Alert.jade
+++ b/client/app/dashboard/alert/Alert.jade
@@ -1,5 +1,6 @@
 .modal-header
   h4.modal-title {{ alertTitle }}
 .modal-body {{ alertMessage }}
-.modal-footer(ng-show="allowAlertClose")
-  button.btn.btn-default(ng-click="closeAlert()", ng-show="allowAlertClose") Close
+.modal-footer(ng-show="allowAlertOkay || allowAlertClose")
+  button.btn.btn-primary(ng-click="okayAlert()", ng-show="allowAlertOkay") {{ alertOkayText ? alertOkayText : "OK" }}
+  button.btn.btn-default(ng-click="closeAlert()", ng-show="allowAlertClose") {{ alertCloseText ? alertCloseText : "Close" }}

--- a/client/app/dashboard/alert/Alert.js
+++ b/client/app/dashboard/alert/Alert.js
@@ -5,6 +5,10 @@ angular.module('dashboard.Alert', [
 
 .controller('AlertCtrl', function AlertCtrl($scope, $modalInstance) {
 
+  $scope.okayAlert = function() {
+    $modalInstance.close();
+  };
+
   $scope.closeAlert = function() {
     $modalInstance.close();
   };

--- a/client/common/services/SessionService.js
+++ b/client/common/services/SessionService.js
@@ -15,7 +15,7 @@ angular.module('dashboard.services.Session', [
 
   this.logIn = function(email, password) {
 	  var authModel = "Users";
-	  if (config.authModel) authModel = config.authModel; 
+	  if (config.authModel) authModel = config.authModel;
        return Utils.apiHelper('POST', authModel + '/login?include=user', { email: email, password: password })
 	      .then(function(userInfo) {
 	        return Utils.apiHelper('GET', 'Roles?access_token=' + userInfo.id)
@@ -36,14 +36,14 @@ angular.module('dashboard.services.Session', [
 	                      roleMap.description = role.description;
 	                    }
 	                  }
-	                  $cookies.roles = JSON.stringify(roleMappings);	                  
+	                  $cookies.roles = JSON.stringify(roleMappings);
 	                  return userInfo;
-	              
+
 	              })["catch"](function() {
 	                  $cookies.session = null;
 	                  return $q.reject(arguments);
 	                });
-	            
+
 	          })["catch"](function() {
 	              $cookies.session = null;
 	              return $q.reject(arguments);
@@ -58,12 +58,13 @@ angular.module('dashboard.services.Session', [
   this.logOut = function() {
   	var authModel = "Users";
   	if (config.authModel) authModel = config.authModel;
-		var accessToken = $cookies.accessToken;
-		$cookieStore.remove('username');
-		$cookieStore.remove('userId');
-		$cookieStore.remove('accessToken');
-		$cookieStore.remove('roles');
-		$cookieStore.remove('session');
+	  var accessToken = $cookies.accessToken;
+	  $cookieStore.remove('username');
+	  $cookieStore.remove('userId');
+	  $cookieStore.remove('accessToken');
+	  $cookieStore.remove('roles');
+	  $cookieStore.remove('session');
+	  session = null;
 	  return Utils.apiHelper('POST', authModel + '/logout?access_token=' + accessToken);
   };
 
@@ -72,6 +73,4 @@ angular.module('dashboard.services.Session', [
   };
 
   init();
-})
-
-;
+});


### PR DESCRIPTION
* I used interval instead of timeout to prevent and disregard previous timeout calls by setting the repeat count to 1 only.
* I used modal instead of simple alert dialog to make it prettier and alert dialog cannot be closed programmatically.
* I modified the Alert Modal to add OK button, we can customize button texts for OK and Close, as well as override okayAlert and closeAlert functions through scope from a controller.
* I moved the SessionTimeout handler inside stateChangeStart to call timeout once state has changed.
* I set session to null to disable call on session timeout once logged out.