### PR TITLE
Updated bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "ace-builds": "~1.1.8",
     "oclazyload": "~0.5.1",
     "angular-google-chart": "~0.0.11",
-    "eonasdan-bootstrap-datetimepicker": "~4.0.0",
+    "eonasdan-bootstrap-datetimepicker": "~4.7.14",
     "moment": "~2.9.0",
     "fullcalendar": "~2.6.0",
     "ng-slider": "~2.1.9",


### PR DESCRIPTION
Upgrading eonasdan-bootstrap-datetimepicker from v4.0.0 to v4.7.14 resolves a bug that occurs when selecting a date from the picker in  'YYYY' format. This bug blocks related loopback models from being updated.