### PR TITLE
Added a watcher for data to clear selected item if empty

### DIFF
--- a/client/common/directives/ModelFieldReference/ModelFieldReference.js
+++ b/client/common/directives/ModelFieldReference/ModelFieldReference.js
@@ -61,6 +61,13 @@ angular.module('dashboard.directives.ModelFieldReference', [
       scope.selected.item = null; //for single select; initialize to null so placeholder is displayed
       scope.list = [];
 
+      /**
+       * Watch for scope.data. If it has no data, it will clear the selected item/s. 
+       */
+      scope.$watch('data', function() {
+        if (!scope.data) scope.selected = {};
+      });
+
       function replaceSessionVariables(string) {
         if (typeof string !== 'string') return string;
         try {


### PR DESCRIPTION
The issue here is that, even the data is `null` it doesn't clear the selected item. It causes to persist the selected item in the dropdown which should not. 